### PR TITLE
Remove alpha channel

### DIFF
--- a/core/backend.py
+++ b/core/backend.py
@@ -18,7 +18,7 @@ from config import PATH_TO_CKPT, PATH_TO_LABELS, NUM_CLASSES
 
 
 def read_image(image_data):
-    image = Image.open(io.BytesIO(image_data)).convert("RGB").convert("RGB")
+    image = Image.open(io.BytesIO(image_data)).convert("RGB")
     return image
 
 def preprocess_image(image):


### PR DESCRIPTION
Currently when a PNG image with an alpha channel is used as input, it fails to preprocess the image. I updated the `preprocess_image()` function to strip the alpha channel.

Should fix #8 