### PR TITLE
Added api endpoint to return model labels list

### DIFF
--- a/api/model.py
+++ b/api/model.py
@@ -24,18 +24,28 @@ class Model(Resource):
 
 model_wrapper = ModelWrapper()
 
-model_labels = api.model('ModelLabels', {
+model_label = api.model('ModelLabel', {
     'id': fields.String(required=True, description='Label identifier'),
     'name': fields.String(required=True, description='Label'),
+})
+
+labels_response = api.model('LabelsResponse', {
+    'status': fields.String(required=True, description='Response status message'),
+    'labels': fields.List(fields.Nested(model_label), description='Labels that can be predicted by the model')
 })
 
 @api.route('/labels')
 class Labels(Resource):
     @api.doc('get_labels')
-    @api.marshal_with(model_labels)
+    @api.marshal_with(labels_response)
     def get(self):
         '''Return the list of labels that can be predicted by the model'''
-        return model_wrapper.categories
+        result = {'status': 'error'}
+
+        result['labels'] = model_wrapper.categories
+        result['status'] = 'ok'
+
+        return result
 
 label_prediction = api.model('LabelPrediction', {
     'label_id': fields.String(required=False, description='Label identifier'),

--- a/api/model.py
+++ b/api/model.py
@@ -30,7 +30,7 @@ model_label = api.model('ModelLabel', {
 })
 
 labels_response = api.model('LabelsResponse', {
-    'status': fields.String(required=True, description='Response status message'),
+    'count': fields.String(required=True, description='Number of labels returned'),
     'labels': fields.List(fields.Nested(model_label), description='Labels that can be predicted by the model')
 })
 
@@ -40,11 +40,9 @@ class Labels(Resource):
     @api.marshal_with(labels_response)
     def get(self):
         '''Return the list of labels that can be predicted by the model'''
-        result = {'status': 'error'}
-
+        result = {}
         result['labels'] = model_wrapper.categories
-        result['status'] = 'ok'
-
+        result['count'] = len(model_wrapper.categories)
         return result
 
 label_prediction = api.model('LabelPrediction', {

--- a/api/model.py
+++ b/api/model.py
@@ -22,6 +22,21 @@ class Model(Resource):
         return MODEL_META_DATA
 
 
+model_wrapper = ModelWrapper()
+
+model_labels = api.model('ModelLabels', {
+    'id': fields.String(required=True, description='Label identifier'),
+    'name': fields.String(required=True, description='Label'),
+})
+
+@api.route('/labels')
+class Labels(Resource):
+    @api.doc('get_labels')
+    @api.marshal_with(model_labels)
+    def get(self):
+        '''Return the list of labels that can be predicted by the model'''
+        return model_wrapper.categories
+
 label_prediction = api.model('LabelPrediction', {
     'label_id': fields.String(required=False, description='Label identifier'),
     'label': fields.String(required=True, description='Class label'),
@@ -42,8 +57,6 @@ image_parser.add_argument('threshold', type=float, default=0.7)
 @api.route('/predict')
 class Predict(Resource):
 
-    model_wrapper = ModelWrapper()
-
     @api.doc('predict')
     @api.expect(image_parser)
     @api.marshal_with(predict_response)
@@ -55,7 +68,7 @@ class Predict(Resource):
         threshold = args['threshold']
         image_data = args['image'].read()
         image = read_image(image_data)
-        label_preds = self.model_wrapper.predict(image, threshold)
+        label_preds = model_wrapper.predict(image, threshold)
         
         result['predictions'] = label_preds
         result['status'] = 'ok'

--- a/api/model.py
+++ b/api/model.py
@@ -30,7 +30,7 @@ model_label = api.model('ModelLabel', {
 })
 
 labels_response = api.model('LabelsResponse', {
-    'count': fields.String(required=True, description='Number of labels returned'),
+    'count': fields.Integer(required=True, description='Number of labels returned'),
     'labels': fields.List(fields.Nested(model_label), description='Labels that can be predicted by the model')
 })
 


### PR DESCRIPTION
I added a `/model/labels` endpoint that returns the list of labels and thier id that the model could return.

This list allows application developers access to what potential labels can be returned by a prediction instead of being restricted to the list of labels returned by a single prediction.