### PR TITLE
Explicitly remove default namespace for Swagger UI

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -8,4 +8,5 @@ api = Api(
 	version=API_VERSION,
 	description=API_DESC)
 
+api.namespaces.clear()
 api.add_namespace(model_ns)


### PR DESCRIPTION
This removes the `default` (unused) API namespace to force Swagger UI not to display it.

Before:
![screen shot 2018-07-25 at 14 25 43](https://user-images.githubusercontent.com/1036807/43200798-f6a868f8-9016-11e8-93db-18e66851e208.png)

After:
![screen shot 2018-07-25 at 14 25 16](https://user-images.githubusercontent.com/1036807/43200799-f9eb6d6c-9016-11e8-8b60-4f17b166cb00.png)




