### PR TITLE
Make API titles and metadata more user friendly

### DIFF
--- a/api/model.py
+++ b/api/model.py
@@ -10,6 +10,8 @@ model_meta = api.model('ModelMetadata', {
     'id': fields.String(required=True, description='Model identifier'),
     'name': fields.String(required=True, description='Model name'),
     'description': fields.String(required=True, description='Model description'),
+    'type': fields.String(required=True, description='Model type'),
+    'source': fields.String(required=True, description='Model source'),
     'license': fields.String(required=False, description='Model license')
 })
 

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ RESTPLUS_MASK_SWAGGER = False
 
 # API metadata
 API_TITLE = 'Object Detector'
-API_DESC = 'Upload an image to predict objects and their bounding boxes.'
+API_DESC = 'Localize and identify multiple objects in a single image.'
 API_VERSION = '0.1'
 
 # default model

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ RESTPLUS_MASK_SWAGGER = False
 
 # API metadata
 API_TITLE = 'Object Detector'
-API_DESC = 'Upload an image to predict the pictured objects and their bounding boxes.'
+API_DESC = 'Upload an image to predict objects and their bounding boxes.'
 API_VERSION = '0.1'
 
 # default model

--- a/config.py
+++ b/config.py
@@ -8,7 +8,7 @@ RESTPLUS_MASK_SWAGGER = False
 # Application settings
 
 # API metadata
-API_TITLE = 'Object Detector'
+API_TITLE = 'MAX Object Detector'
 API_DESC = 'Localize and identify multiple objects in a single image.'
 API_VERSION = '0.1'
 

--- a/config.py
+++ b/config.py
@@ -8,8 +8,8 @@ RESTPLUS_MASK_SWAGGER = False
 # Application settings
 
 # API metadata
-API_TITLE = 'Model Asset Exchange Server'
-API_DESC = 'An API for serving models'
+API_TITLE = 'Object Detector'
+API_DESC = 'Upload an image to predict the pictured objects and their bounding boxes.'
 API_VERSION = '0.1'
 
 # default model
@@ -31,6 +31,7 @@ MODEL_META_DATA = {
     'id': '{}-tf-mobilenet'.format(MODEL_NAME.lower()),
     'name': '{} TensorFlow Model'.format(MODEL_NAME),
     'description': '{} TensorFlow model trained on MobileNet'.format(MODEL_NAME),
-    'type': 'object_detection',
+    'type': 'Object Detection',
+    'source': 'https://developer.ibm.com/exchanges/models/all/max-object-detector/',
     'license': '{}'.format(MODEL_LICENSE)
 }

--- a/tests/test.py
+++ b/tests/test.py
@@ -12,7 +12,7 @@ def test_swagger():
 
     json = r.json()
     assert 'swagger' in json
-    assert json.get('info') and json.get('info').get('title') == 'Model Asset Exchange Server'
+    assert json.get('info') and json.get('info').get('title') == 'Object Detector'
 
 
 def test_metadata():
@@ -26,6 +26,8 @@ def test_metadata():
     assert metadata['id'] == 'ssd_mobilenet_v1_coco_2017_11_17-tf-mobilenet'
     assert metadata['name'] == 'ssd_mobilenet_v1_coco_2017_11_17 TensorFlow Model'
     assert metadata['description'] == 'ssd_mobilenet_v1_coco_2017_11_17 TensorFlow model trained on MobileNet'
+    assert metadata['type'] == 'Object Detection'
+    assert metadata['source'] == 'https://developer.ibm.com/exchanges/models/all/max-object-detector/'
     assert metadata['license'] == 'ApacheV2'
 
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -12,7 +12,7 @@ def test_swagger():
 
     json = r.json()
     assert 'swagger' in json
-    assert json.get('info') and json.get('info').get('title') == 'Object Detector'
+    assert json.get('info') and json.get('info').get('title') == 'MAX Object Detector'
 
 
 def test_metadata():


### PR DESCRIPTION
This is an example PR to highlight what changes would be required to make the API more user friendly, and make the metadata more informative. Ideally, we want to make these changes to the CODAIT/MAX-Framework if everyone agrees.

If we merge, I can do the same for the MAX-Framework if that's ok @bdwyer2 @djalova 

Changes include:
- Changing the title from 'Model Asset Exchange Server' to 'Object Detector' and make the description more informative 
- Add a 'type' field to the metadata to indicate that this model is an 'Object Detector'
- Add a 'source' field to the metadata to provide the user with a link back to codait/source code
- Update the associated tests
