### PR TITLE
Avoid creating a Docker layer containing the compressed model file.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,14 @@ ARG data_file=data.tar.gz
 
 WORKDIR /workspace
 
-RUN wget -nv --show-progress --progress=bar:force:noscroll ${model_bucket}/${model_file} --output-document=/workspace/assets/${model_file}
-RUN tar -x -C assets/ -f assets/${model_file} -v && rm assets/${model_file}
+RUN wget -nv --show-progress --progress=bar:force:noscroll ${model_bucket}/${model_file} --output-document=assets/${model_file} && \
+  tar -x -C assets/ -f assets/${model_file} -v && rm assets/${model_file}
 
-RUN wget -nv --show-progress --progress=bar:force:noscroll ${model_bucket}/${data_file} --output-document=/workspace/assets/${data_file}
-RUN tar -x -C assets/ -f assets/${data_file} -v && rm assets/${data_file}
+RUN wget -nv --show-progress --progress=bar:force:noscroll ${model_bucket}/${data_file} --output-document=assets/${data_file} && \
+  tar -x -C assets/ -f assets/${data_file} -v && rm assets/${data_file}
 
-RUN wget -nv --show-progress --progress=bar:force:noscroll https://github.com/IBM/MAX-Object-Detector-Web-App/archive/v1.2.tar.gz
-RUN tar -xf v1.2.tar.gz && rm v1.2.tar.gz
+RUN wget -nv --show-progress --progress=bar:force:noscroll https://github.com/IBM/MAX-Object-Detector-Web-App/archive/v1.2.tar.gz && \
+  tar -xf v1.2.tar.gz && rm v1.2.tar.gz
 
 RUN mv ./MAX-Object-Detector-Web-App-1.2/static static
 


### PR DESCRIPTION
Download and delete the compressed model file in the same layer to avoid an (often oversized) additional Docker layer.