### PR TITLE
Undefined name: from utils.ops import reframe_box_masks_to_image_masks

### DIFF
--- a/core/model.py
+++ b/core/model.py
@@ -11,6 +11,7 @@ from config import PATH_TO_CKPT, PATH_TO_LABELS, NUM_CLASSES
 import sys
 sys.path.insert(0, '../')
 from utils import label_map_util
+from utils.ops import reframe_box_masks_to_image_masks
 
 logger = logging.getLogger()
 
@@ -77,10 +78,10 @@ class ModelWrapper(MAXModelWrapper):
                     real_num_detection = tf.cast(tensor_dict['num_detections'][0], tf.int32)
                     detection_boxes = tf.slice(detection_boxes, [0, 0], [real_num_detection, -1])
                     detection_masks = tf.slice(detection_masks, [0, 0, 0], [real_num_detection, -1, -1])
-                    detection_masks_reframed = utils_ops.reframe_box_masks_to_image_masks(detection_masks,
-                                                                                          detection_boxes,
-                                                                                          image.shape[0],
-                                                                                          image.shape[1])
+                    detection_masks_reframed = reframe_box_masks_to_image_masks(detection_masks,
+                                                                                detection_boxes,
+                                                                                image.shape[0],
+                                                                                image.shape[1])
                     detection_masks_reframed = tf.cast(tf.greater(detection_masks_reframed, 0.5), tf.uint8)
                     # Follow the convention by adding back the batch dimension
                     tensor_dict['detection_masks'] = tf.expand_dims(detection_masks_reframed, 0)


### PR DESCRIPTION
__utils_ops__ is an _undefined name_ in this context which has the potential to raise NameError at runtime.

[flake8](http://flake8.pycqa.org) testing of https://github.com/IBM/MAX-Object-Detector on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./core/model.py:80:48: F821 undefined name 'utils_ops'
                    detection_masks_reframed = utils_ops.reframe_box_masks_to_image_masks(detection_masks,
                                               ^
1     F821 undefined name 'utils_ops'
1
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree