### PR TITLE
Use 1.1.3 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM codait/max-base:v1.1.2
+FROM codait/max-base:v1.1.3
 
 ARG model_bucket=http://max-assets.s3.us.cloud-object-storage.appdomain.cloud/object-detector/1.0
 ARG model_file=model.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM codait/max-base:v1.1.1
+FROM codait/max-base:v1.1.2
 
 ARG model_bucket=http://max-assets.s3.us.cloud-object-storage.appdomain.cloud/object-detector/1.0
 ARG model_file=model.tar.gz


### PR DESCRIPTION
To inherit the COS fix, which was implemented by https://github.com/IBM/MAX-Framework/pull/24 and published by the codait/max-base v 1.1.3 docker image