### PR TITLE
Install libatlas3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@
 
 FROM codait/max-base:v1.1.3
 
+RUN apt-get update && apt-get -y install libatlas3-base && rm -rf /var/lib/apt/lists/*
+
 ARG model_bucket=https://max-assets-prod.s3.us-south.cloud-object-storage.appdomain.cloud/max-object-detector/1.0.1
 ARG model_file=model.tar.gz
 ARG data_file=data.tar.gz


### PR DESCRIPTION
This is a dependency for linear algebra operations. It just happened to
be that the max-base has installed it, but an experiment on Pi shows
that the default image does not include it. We now install it in this
Docker image just to be safe.