### PR TITLE
update to TF 1.13.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tensorflow==1.12.2
+tensorflow==1.13.1
 Pillow==6.2.0
 numpy==1.17.0
 google==2.0.2


### PR DESCRIPTION
Tensorflow 1.12.2 does not work on ARM but 1.13.1 does. To keep things consistent we will use 1.13.1 for all builds