### PR TITLE
Ignore Dockerfile hadolinter errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@
 
 FROM quay.io/codait/max-base:v1.4.0
 
+# hadolint ignore=DL3004
 RUN sudo apt-get update && sudo apt-get -y install libatlas3-base && sudo rm -rf /var/lib/apt/lists/*
 
 ARG model_bucket=https://max-cdn.cdn.appdomain.cloud/max-object-detector/1.0.2
@@ -30,17 +31,23 @@ RUN if [ "$use_pre_trained_model" = "true" ] ; then\
     wget -nv --show-progress --progress=bar:force:noscroll ${model_bucket}/${data_file} --output-document=assets/${data_file} && \
            tar -x -C assets/ -f assets/${data_file} -v && rm assets/${data_file}; fi
 
+# hadolint ignore=DL3045,DL4006
 RUN wget -O - -nv --show-progress --progress=bar:force:noscroll https://github.com/IBM/MAX-Object-Detector-Web-App/archive/v2.1.tar.gz | \
   tar zxvf - --strip-components=1 --wildcards 'MAX-Object-Detector-Web-App-*/static'
 
+# hadolint ignore=DL3045,DL3059
 COPY requirements.txt .
+
+# hadolint ignore=DL3042
 RUN pip install -r requirements.txt
 
+# hadolint ignore=DL3045
 COPY . .
 
 # Template substitution: Replace @model@ with the proper model name
 RUN sed s/@model@/${model}/ config.py.in > config.py
 
+# hadolint ignore=DL3059,SC1075
 RUN if [ "$use_pre_trained_model" = "true" ] ; then \
       # validate downloaded pre-trained model assets
       sha512sum -c sha512sums-${model}.txt ; \
@@ -53,4 +60,5 @@ RUN if [ "$use_pre_trained_model" = "true" ] ; then \
 
 EXPOSE 5000
 
+# hadolint ignore=DL3025
 CMD python app.py


### PR DESCRIPTION
Ignore Dockerfile hadolinter errors

Related to #163 

This will allow hadolint to pass in a pipeline from the Cloud Native Toolkit while the problems get addressed in the Dockerfile

You can checkout hadolint here https://github.com/hadolint/hadolint

You can lint the Dockerfile with the hadolint UI https://hadolint.github.io/hadolint/

